### PR TITLE
feat(fortune-room): pass null if no cookie saved

### DIFF
--- a/pages/rooms/fortune-cookie/index.tsx
+++ b/pages/rooms/fortune-cookie/index.tsx
@@ -127,7 +127,7 @@ export async function getServerSideProps({
 }): Promise<{ props: FortunePage }> {
   const cookies = new Cookies(req, res)
   const preferences = cookies.get(PANIC_ROOM_PREFERENCES) || null
-  const fortuneCookieId = Number(cookies.get(FORTUNE_COOKIE)) || 0
+  const fortuneCookieId = Number(cookies.get(FORTUNE_COOKIE))
   const host = req.headers.host
 
   const fortuneCookie = await fetch(
@@ -145,7 +145,7 @@ export async function getServerSideProps({
       host,
       url: req.url,
       fortuneCookieId,
-      fortuneCookie,
+      fortuneCookie: fortuneCookieId ? fortuneCookie : null,
     },
   }
 }


### PR DESCRIPTION
Fixes #27

Users see the general meta images on share if they did not pick their fortune for the day yet. Otherwise, they share theirs